### PR TITLE
Ensure `s` is a string when splitting

### DIFF
--- a/lib/reso_transport.rb
+++ b/lib/reso_transport.rb
@@ -53,7 +53,7 @@ module ResoTransport
   end
 
   def self.split_schema_and_class_name(s)
-    s.partition(/(\w+)$/).first(2).map {|s| s.sub(/\.$/, '') }
+    s.to_s.partition(/(\w+)$/).first(2).map {|s| s.sub(/\.$/, '') }
   end
 
 end


### PR DESCRIPTION
When using this gem, I found that one of our MLSes had one field that passed `nil` to this method for the attribute `ModificationTimestamp`

Here is the property struct that caused the issue:

```ruby
#<struct ResoTransport::Property name="ModificationTimestamp", data_type=nil, attrs={"Name"=>"ModificationTimestamp", "MaxLength"=>"27", :schema=>#<struct ResoTransport::Schema namespace="ODataService">}, multi=nil, enum=nil, complex_type=nil, entity_type=nil>
```