### PR TITLE
Accomodate bad datasystem formats

### DIFF
--- a/lib/reso_transport/datasystem_parser.rb
+++ b/lib/reso_transport/datasystem_parser.rb
@@ -20,7 +20,7 @@ module ResoTransport
     #       ResourcePath ->
 
     def resources
-      @resources ||= @json['value'].map { |v| v['Resources'] }.flatten.map { |r| [r['Name'], r] }.to_h
+      @resources ||= @json['value'].map { |v| v['Resources'] }.flatten.compact.map { |r| [r['Name'], r] }.to_h
     end
   end
 end

--- a/lib/reso_transport/version.rb
+++ b/lib/reso_transport/version.rb
@@ -1,3 +1,3 @@
 module ResoTransport
-  VERSION = '1.5.6'.freeze
+  VERSION = '1.5.7'.freeze
 end


### PR DESCRIPTION
There are feeds that exist that have the datasystem endpoint, and reference it in their metadata, so we parse it.  It does not have the `Resources` property however, so we end up raising an error when parsing it looking for a value inside of an object that ends up being nil.