### PR TITLE
Use enum value as-is rather than mapping to member name.

### DIFF
--- a/lib/reso_transport/enum.rb
+++ b/lib/reso_transport/enum.rb
@@ -19,19 +19,8 @@ module ResoTransport
     end
 
     def encode_value(value)
-      "'#{mapping.invert.fetch(value, value)}'"
+      "'#{value}'"
     end
-
-    def mapping
-      @mapping ||= generate_member_map || {}
-    end
-
-    def generate_member_map
-      members.map {|mem|
-        { mem.name => mem.annotation || mem.name }  
-      }.reduce(:merge!)
-    end
-
   end
 end
 

--- a/lib/reso_transport/version.rb
+++ b/lib/reso_transport/version.rb
@@ -1,3 +1,3 @@
 module ResoTransport
-  VERSION = '1.5.8'.freeze
+  VERSION = '1.5.9'.freeze
 end


### PR DESCRIPTION
Per this update
(https://updates.bridgedataoutput.com/2020/11/02/metadata-update/) the
member names no longer include space and instead the annotation name has
spaces. If you map annotations back to the member name, it will
translate something like "Jackson Heights" to "Jackson_Heights" which
will _not_ result in any query results.

Note this could have side-effects elsewhere but we will see after.