### PR TITLE
WSAS-02853 Trestle replication support

### DIFF
--- a/lib/reso_transport/query.rb
+++ b/lib/reso_transport/query.rb
@@ -23,6 +23,11 @@ module ResoTransport
       end
     end
 
+    def set_query_params(params)
+      query_parameters.merge!(params)
+      self
+    end
+
     def limit(size)
       options[:top] = size
       self
@@ -70,7 +75,6 @@ module ResoTransport
 
     def results
       parsed = handle_response response
-
       @next_link = parsed.fetch('@odata.nextLink', nil)
       results = Array(parsed.delete('value'))
       resource.parse(results)
@@ -116,6 +120,10 @@ module ResoTransport
       @options ||= {}
     end
 
+    def query_parameters
+      @query_parameters ||= {}
+    end
+
     def sub_queries
       @sub_queries ||= Hash.new { |h, k| h[k] = { context: 'and', criteria: [] } }
     end
@@ -144,6 +152,7 @@ module ResoTransport
       end
 
       params['$filter'] = compile_filters unless sub_queries.empty?
+      params.merge!(query_parameters) unless query_parameters.empty?
 
       params
     end

--- a/lib/reso_transport/version.rb
+++ b/lib/reso_transport/version.rb
@@ -1,3 +1,3 @@
 module ResoTransport
-  VERSION = '1.5.16'.freeze
+  VERSION = '1.5.17'.freeze
 end

--- a/test/reso_transport/query_test.rb
+++ b/test/reso_transport/query_test.rb
@@ -13,6 +13,15 @@ class ResoTransport::QueryTest < Minitest::Test
     client.resources['Property'].query
   end
 
+  def test_set_query_params
+    q = query
+    q.limit(1).set_query_params({ replication: true }).results
+      expected = { '$top' => 1, replication: true }
+
+    assert_equal  expected, q.compile_params
+    assert_match /replication?/, q.next_link
+  end
+
   # Test all the easy stuff first
   def test_limit
     expected = { '$top' => 1 }


### PR DESCRIPTION
**What**
Populate job on Trestle type adapters can not be completed on forge on days with over 800K+ resources
See [Trestle Extension Docs](https://trestle-documentation.corelogic.com/webapi-reference.html?http#trestle-odata-extensions) for context


**How**
* add #set_query_params to ResoTransport::Query to support trestle replication
* work to be done on forge to use this update

Ticket: [WSAS-2853](https://pr-corpnet.atlassian.net/browse/WSAS-2853)