### PR TITLE
WSAS-2853 - Trestle replication

### DIFF
--- a/lib/reso_transport/query.rb
+++ b/lib/reso_transport/query.rb
@@ -80,15 +80,26 @@ module ResoTransport
       resource.parse(results)
     end
 
-    # Can only be accessed after results call
+    # Can only be accessed after results call or if it's being set
     def next_link
       @next_link
     end
 
+    # used for setting the next_link with trestle's replication strategy
+    def next_link=(link)
+      @next_link = link
+    end
+
     def response
-      resource.get(compile_params)
+      next_link_or_params = using_trestle_replication? ? next_link : compile_params
+
+      resource.get(next_link_or_params)
     rescue Faraday::ConnectionFailed
       raise NoResponse.new(resource.request, nil, resource)
+    end
+
+    def using_trestle_replication?
+      compile_params[:replication] && next_link.present?
     end
 
     def handle_response(response)

--- a/lib/reso_transport/query.rb
+++ b/lib/reso_transport/query.rb
@@ -91,14 +91,14 @@ module ResoTransport
     end
 
     def response
-      next_link_or_params = using_trestle_replication? ? next_link : compile_params
+      next_link_or_params = use_next_link? ? next_link : compile_params
 
       resource.get(next_link_or_params)
     rescue Faraday::ConnectionFailed
       raise NoResponse.new(resource.request, nil, resource)
     end
 
-    def using_trestle_replication?
+    def use_next_link?
       compile_params[:replication] && next_link.present?
     end
 

--- a/lib/reso_transport/version.rb
+++ b/lib/reso_transport/version.rb
@@ -1,3 +1,3 @@
 module ResoTransport
-  VERSION = '1.5.17'.freeze
+  VERSION = '1.5.18'.freeze
 end


### PR DESCRIPTION
**What**
Support next_link fetches from trestle feeds


**How**
* add #next_link= setter to ResoTransport::Query to setting next_link on subsequent request
* use next_link for trestle feed fetches if replication is enabled


Ticket: [WSAS-2853](https://pr-corpnet.atlassian.net/browse/WSAS-2853)