### PR TITLE
Nestable queries

### DIFF
--- a/lib/reso_transport/query.rb
+++ b/lib/reso_transport/query.rb
@@ -139,10 +139,10 @@ module ResoTransport
     end
 
     class SubQuery
-      def initialize context, parens: false
+      def initialize context, criteria=[], parens: false
         @context = context
         @parens = parens
-        @criteria = []
+        @criteria = criteria
       end
 
       attr_reader :context, :parens, :criteria
@@ -165,10 +165,10 @@ module ResoTransport
 
     def compile_filters
       global, *filter_groups = sub_queries
-      query = SubQuery.new("and")
-      query.criteria << global
-      query.criteria << filter_groups.map(&:to_s).join(' and ')
-      query.to_s
+      SubQuery.new("and", [
+        global,
+        SubQuery.new("and", filter_groups),
+      ]).to_s
     end
 
     public def compile_params

--- a/lib/reso_transport/query.rb
+++ b/lib/reso_transport/query.rb
@@ -17,7 +17,7 @@ module ResoTransport
     %i[eq ne gt ge lt le].each do |op|
       define_method(op) do |conditions|
         conditions.each_pair do |k, v|
-          current_query_context.criteria << "#{k} #{op} #{encode_value(k, v)}"
+          current_query_context.push "#{k} #{op} #{encode_value(k, v)}"
         end
         return self
       end
@@ -124,18 +124,18 @@ module ResoTransport
     end
 
     def new_query_context(context)
-      @last_query_context ||= 0
-      @current_query_context = @last_query_context + 1
-      sub_queries[@current_query_context] = SubQuery.new(context, parens: true)
+      @last_query_context_index ||= 0
+      @current_query_context_index = @last_query_context_index + 1
+      sub_queries[@current_query_context_index] = SubQuery.new(context, parens: true)
     end
 
     def clear_query_context
-      @last_query_context = @current_query_context
-      @current_query_context = nil
+      @last_query_context_index = @current_query_context_index
+      @current_query_context_index = nil
     end
 
     def current_query_context
-      sub_queries[@current_query_context || 0]
+      sub_queries[@current_query_context_index || 0]
     end
 
     class SubQuery
@@ -153,6 +153,11 @@ module ResoTransport
         out = "(#{out})" if parens?
         out
       end
+
+      def push x
+        criteria << x
+      end
+      alias_method :<<, :push
 
       def length
         criteria.length

--- a/lib/reso_transport/query.rb
+++ b/lib/reso_transport/query.rb
@@ -124,7 +124,7 @@ module ResoTransport
 
     def current_query_context
       @current_query_context ||= nil
-      sub_queries[@current_query_context || :global][:criteria]
+      sub_queries[@current_query_context || :global].criteria
     end
 
     def options
@@ -136,7 +136,13 @@ module ResoTransport
     end
 
     def sub_queries
-      @sub_queries ||= Hash.new { |h, k| h[k] = { context: 'and', criteria: [] } }
+      @sub_queries ||= Hash.new { |h, k| h[k] = SubQuery.new("and") }
+    end
+
+    SubQuery = Struct.new(:context) do
+      def criteria
+        @criteria ||= []
+      end
     end
 
     def compile_filters

--- a/lib/reso_transport/query.rb
+++ b/lib/reso_transport/query.rb
@@ -90,6 +90,8 @@ module ResoTransport
       @next_link = link
     end
 
+    private
+
     def response
       use_next_link? ? resource.get_next_link_results(next_link) : resource.get(compile_params)
     rescue Faraday::ConnectionFailed
@@ -144,16 +146,16 @@ module ResoTransport
 
       filter_chunks = []
 
-      filter_chunks << global[:criteria].join(" #{global[:context]} ") if global && global[:criteria]&.any?
+      filter_chunks << global.criteria.join(" #{global[:context]} ") if global && global.criteria.any?
 
       filter_chunks << filter_groups.map do |g|
-        "(#{g[:criteria].join(" #{g[:context]} ")})"
+        "(#{g.criteria.join(" #{g[:context]} ")})"
       end.join(' and ')
 
       filter_chunks.reject { |c| c == '' }.join(' and ')
     end
 
-    def compile_params
+    public def compile_params
       params = {}
 
       options.each_pair do |k, v|

--- a/lib/reso_transport/query.rb
+++ b/lib/reso_transport/query.rb
@@ -169,11 +169,7 @@ module ResoTransport
     end
 
     def compile_filters
-      global, *filter_groups = sub_queries
-      SubQuery.new("and", [
-        global,
-        SubQuery.new("and", filter_groups),
-      ]).to_s
+      SubQuery.new("and", sub_queries).to_s
     end
 
     public def compile_params

--- a/lib/reso_transport/query.rb
+++ b/lib/reso_transport/query.rb
@@ -124,18 +124,17 @@ module ResoTransport
     end
 
     def new_query_context(context)
-      @last_query_context_index ||= 0
-      @current_query_context_index = @last_query_context_index + 1
-      sub_queries[@current_query_context_index] = SubQuery.new(context, parens: true)
+      sub_query = SubQuery.new(context, parens: true)
+      current_query_context.push sub_query
+      sub_queries.push sub_query
     end
 
     def clear_query_context
-      @last_query_context_index = @current_query_context_index
-      @current_query_context_index = nil
+      sub_queries.pop
     end
 
     def current_query_context
-      sub_queries[@current_query_context_index || 0]
+      sub_queries.last
     end
 
     class SubQuery
@@ -169,7 +168,7 @@ module ResoTransport
     end
 
     def compile_filters
-      SubQuery.new("and", sub_queries).to_s
+      sub_queries.first.to_s
     end
 
     public def compile_params

--- a/lib/reso_transport/query.rb
+++ b/lib/reso_transport/query.rb
@@ -114,7 +114,7 @@ module ResoTransport
     def new_query_context(context)
       @last_query_context ||= 0
       @current_query_context = @last_query_context + 1
-      sub_queries[@current_query_context][:context] = context
+      sub_queries[@current_query_context].context = context
     end
 
     def clear_query_context
@@ -139,9 +139,13 @@ module ResoTransport
       @sub_queries ||= Hash.new { |h, k| h[k] = SubQuery.new("and") }
     end
 
-    SubQuery = Struct.new(:context) do
+    SubQuery = Struct.new(:context, :criteria) do
       def criteria
         @criteria ||= []
+      end
+
+      def to_s
+        criteria.join(" #{context} ")
       end
     end
 
@@ -152,10 +156,10 @@ module ResoTransport
 
       filter_chunks = []
 
-      filter_chunks << global.criteria.join(" #{global[:context]} ") if global && global.criteria.any?
+      filter_chunks << global.to_s if global && global.criteria.any?
 
       filter_chunks << filter_groups.map do |g|
-        "(#{g.criteria.join(" #{g[:context]} ")})"
+        "(#{g})"
       end.join(' and ')
 
       filter_chunks.reject { |c| c == '' }.join(' and ')

--- a/lib/reso_transport/query.rb
+++ b/lib/reso_transport/query.rb
@@ -164,9 +164,7 @@ module ResoTransport
     end
 
     def compile_filters
-      filter_groups = sub_queries.dup
-      global = filter_groups.shift
-
+      global, *filter_groups = sub_queries
       query = SubQuery.new("and")
       query.criteria << global
       query.criteria << filter_groups.map(&:to_s).join(' and ')


### PR DESCRIPTION
Hello, thank you for ResoTransport! I'm using this in one of my projects, and its saved me from having to reinvent the wheel.

Working with the query API, I noticed that I wasn't able to construct complex nested queries. My use-case is a client to wanted to pull down all listings within a certain area, but only the active and bumpable-buyer listings. In addition, he wanted to see all of his own listings, regardless of the status. The query looks something like this:

```
( CountyOrParish = 'Multnomah' or CountyOrParish = 'Clackamas' or CountyOrParish = 'Washington' or CountyOrParish = 'Clark' )
and
(
  ( MlsStatus = 'Active' or MlsStatus = 'BumpableBuyer' )
  or
  ( ListOfficeMlsId eq 'JMAP02'
    and
    ( MlsStatus = 'Pending' or MlsStatus = 'Sold' or MlsStatus = 'SoldNotListed' )
  )
)
```

This is not possible to construct using the current query API, but it seems to me that there's no reason it couldn't be, like this:
```ruby
      query.
        eq(CountyOrParish: ["Multnomah", "Clackamas", "Washington", "Clark"]).
        any {
          eq(MlsStatus: ["Active", "BumpableBuyer"])
          all {
            eq(ListOfficeMlsId: "JMAP02")
            eq(MlsStatus: ["Pending", "Sold", "SoldNotListed"])
          }
        }
```
Note that I have also extended `#eq` to accept an array for brevity, but that extension is not in this PR. This PR just makes the deep nesting possible.

All existing tests pass with the new implementation, so it _should_ be backwards compatible, but perhaps there are some queries out there that are relying on some idiosyncracy of the old implementation.

Anyways, thoughts? Any interest in merging this?

If desired, I can push a PR for the `.eq(field: [1,2,3])` syntax, as well.


